### PR TITLE
Add missing listener on port 8999.

### DIFF
--- a/config/usr/local/openresty/nginx/conf.d/nginx-httpd.conf
+++ b/config/usr/local/openresty/nginx/conf.d/nginx-httpd.conf
@@ -49,6 +49,25 @@ init_worker_by_lua_block {
 access_log /dev/stdout;
 error_page 400 401 402 403 404 405 406 407 408 409 410 411 412 413 414 415 416 417 418 421 422 423 424 425 426 428 429 431 451 500 501 502 503 504 505 506 507 508 510 511 /error.html;
 
+# Internal server running on port 8999 for handling certificate tasks.
+server {
+    listen 127.0.0.1:8999;
+
+    # Set $environment, required by json_combined log format
+    set_by_lua $environment 'return os.getenv("ENVIRONMENT") or "development"';
+
+    # Increase the body buffer size, to ensure the internal POSTs can always
+    # parse the full POST contents into memory.
+    client_body_buffer_size 128k;
+    client_max_body_size 128k;
+
+    location / {
+      content_by_lua_block {
+        auto_ssl:hook_server()
+      }
+    }
+}
+
 # HTTP -> HTTPS
 server {
     listen 80 default_server;


### PR DESCRIPTION
I missed this very important piece when I implemented this. It's required for internal validation of ACME challenges.