### PR TITLE
Add functionality to preserve url path in redirect.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,7 @@ COPY config /
 RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-auto-ssl \
   && chown nobody /etc/resty-auto-ssl
 
+# Install lua-resty-url \
+RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-url
+
 WORKDIR /usr/local/openresty/nginx

--- a/config/usr/local/openresty/nginx/conf.d/nginx-httpd.conf
+++ b/config/usr/local/openresty/nginx/conf.d/nginx-httpd.conf
@@ -124,13 +124,23 @@ server {
 
     location / {
         rewrite_by_lua_block {
+            local resty_url = require 'resty.url'
             local red = auto_ssl.storage.adapter:get_connection()
             local redirect, err = red:hget("redirects", ngx.var.host)
             if redirect == ngx.null then
                 -- Key has no value, render http 410 error page
                 return ngx.exit(410)
             end
-            return ngx.redirect("https://" .. redirect)
+
+            -- Build full URL, then parse path and replace occurrences of :PATH in redirect
+            local url = string.lower(ngx.var.scheme .. "://" .. ngx.var.host .. ngx.var.uri)
+            local url_parts = resty_url.parse(url)
+            local path = url_parts.path ~= nil and url_parts.path or ""
+            redirect = redirect:gsub(":PATH", path)
+            redirect = resty_url.normalize("https://" .. redirect)
+
+            -- Return normalized redirect URL, enforcing https
+            return ngx.redirect(redirect)
         }
     }
 


### PR DESCRIPTION
This adds the ability for redirects to preserve the URL Path in the redirect. Any occurrence of `:PATH` in a redirect will be replaced with the path from the incoming request.
```
resource "redisdb_hash" "redirects" {
  key = "redirects"
  hash = {
    "example.com"          = "example.net/:PATH"
    "www.example.com"      = "example.net/prefix/:PATH"
  }
}
```

This would cause a request for
* `http://example.com/index.html` => `https://example.net/index.html` 
* `https://www.example.com/downloads/images/image.jpg` => `https://example.net/prefix/downloads/images/image.jpg`
* `https://example.com/folder/foo/bar` => `https://example.net/folder/foo/bar`