### PR TITLE
Increase auto_ssl dict size

### DIFF
--- a/docker/usr/local/openresty/nginx/conf/conf.d/auto-ssl.conf
+++ b/docker/usr/local/openresty/nginx/conf/conf.d/auto-ssl.conf
@@ -1,7 +1,7 @@
 # The "auto_ssl" shared dict should be defined with enough storage space to
 # hold your certificate data. 5MB of storage holds certificates for
 # approximately 500 separate domains.
-lua_shared_dict auto_ssl 5m;
+lua_shared_dict auto_ssl 10m;
 
 # The "auto_ssl" shared dict is used to temporarily store various settings
 # like the secret used by the hook server on port 8999. Do not change or


### PR DESCRIPTION
Attempting to solve

> [lua] ssl_certificate.lua:33: convert_to_der_and_cache(): auto-ssl: 'lua_shared_dict auto_ssl' might be too small - consider increasing its configured size (old entries were removed while adding private key for cruboisestate.com)