### PR TITLE
Update httpd.conf

### DIFF
--- a/docker/usr/local/openresty/nginx/conf/conf.d/httpd.conf
+++ b/docker/usr/local/openresty/nginx/conf/conf.d/httpd.conf
@@ -45,6 +45,10 @@ server {
         return 200 "pong";
     }
 
+    location ~ ^/wp-content/uploads/sites/607/(.*)$ {
+        return 301 https://sightlineministry.org/wp-content/uploads/sites/997/$1$is_args$args;
+    }
+
     location / {
         rewrite_by_lua_block {
             local cjson = require "cjson"


### PR DESCRIPTION
Add special redirect for josh.org to sighlineministry.org

This will redirect every domain if this exact path is requested, which should only happen for josh.org. Targeting josh exactly is much more complex.

cc @clonge

See https://secure.helpscout.net/conversation/3104132274/1464897?viewId=3827955